### PR TITLE
feat: add reusable workflows and templates for Crossplane packages

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,115 @@
+# Reusable Workflows
+
+Centralized workflows that can be called from any repository in the Open Service Portal organization.
+
+## build-crossplane-package.yaml
+
+Standardized workflow for building and publishing Crossplane packages to GitHub Container Registry.
+
+### Conventions
+
+This workflow enforces the following conventions:
+
+- **Package structure**: Must be in `configuration/` directory
+- **Required files**: `configuration/crossplane.yaml` must exist
+- **Build platforms**: Always `linux/amd64,linux/arm64`
+- **Latest tag**: Automatically applied to stable releases (no `-` in version)
+- **Version label**: Applied only to XRD (`configuration/xrd.yaml`)
+
+### Required Package Structure
+
+```
+your-template/
+├── configuration/
+│   ├── crossplane.yaml
+│   ├── xrd.yaml
+│   └── composition.yaml
+├── examples/
+└── README.md
+```
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `package-name` | string | ✅ | - | Package identifier (e.g., `template-dns-record`) |
+| `version` | string | ✅ | - | Version tag (e.g., `v1.0.0`) |
+| `registry` | string | ❌ | `ghcr.io` | Container registry URL |
+| `organisation` | string | ✅ | - | Organization owning the package |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `package-path` | Full registry path (e.g., `ghcr.io/org/package`) |
+
+### Usage Example
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build:
+    uses: open-service-portal/github-org-settings/.github/workflows/build-crossplane-package.yaml@main
+    with:
+      package-name: ${{ github.event.repository.name }}
+      version: ${{ github.ref_name }}
+      organisation: ${{ github.repository_owner }}
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+```
+
+### Version Tagging Behavior
+
+| Version | Published Tags | Description |
+|---------|---------------|-------------|
+| `v1.0.0` | `v1.0.0`, `latest` | Stable release |
+| `v1.0.0-rc1` | `v1.0.0-rc1` | Pre-release (no latest) |
+| `v2.3.4` | `v2.3.4`, `latest` | Updates latest to v2.3.4 |
+| `v0.1.0-beta` | `v0.1.0-beta` | Beta (no latest) |
+
+### What the Workflow Does
+
+1. **Validates** package structure (configuration/ directory required)
+2. **Labels** XRD with version (if xrd.yaml exists)
+3. **Builds** multi-arch package (amd64 + arm64)
+4. **Pushes** to registry with version tag
+5. **Updates** latest tag (stable releases only)
+6. **Reports** summary in GitHub Actions UI
+
+### Troubleshooting
+
+#### "configuration/crossplane.yaml not found"
+Your package must follow the standard structure with files in the `configuration/` directory.
+
+#### "Permission denied" pushing to registry
+Ensure your job has `packages: write` permission:
+```yaml
+permissions:
+  contents: read
+  packages: write
+```
+
+#### "Unable to find reusable workflow"
+The workflow must exist in the `main` branch of the github-org-settings repository.
+
+### Migration from Flexible Structure
+
+If your packages use root directory structure, migrate them:
+```bash
+# Create configuration directory
+mkdir -p configuration
+
+# Move package files
+mv crossplane.yaml xrd.yaml composition.yaml configuration/
+
+# Update any references in your files
+git add -A
+git commit -m "chore: migrate to standard package structure"
+```

--- a/.github/workflows/build-crossplane-package.yaml
+++ b/.github/workflows/build-crossplane-package.yaml
@@ -1,0 +1,160 @@
+# Reusable workflow for building Crossplane Configuration packages
+# This workflow provides a standardized build process for all template repositories
+name: Build Crossplane Package
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: 'Name of the package (e.g., configuration-dns-record)'
+        required: true
+        type: string
+      version:
+        description: 'Version tag (e.g., v1.0.0)'
+        required: true
+        type: string
+      registry:
+        description: 'Container registry URL (default: ghcr.io)'
+        required: false
+        type: string
+        default: 'ghcr.io'
+      organisation:
+        description: 'Organization or user owning the package'
+        required: true
+        type: string
+
+    outputs:
+      package-path:
+        description: 'Full package path in registry'
+        value: ${{ jobs.build.outputs.package-path }}
+
+jobs:
+  build:
+    name: Build and Push Package
+    runs-on: ubuntu-latest
+    
+    outputs:
+      package-path: ${{ inputs.registry }}/${{ inputs.organisation }}/${{ inputs.package-name }}
+
+    env:
+      VERSION: ${{ inputs.version }}
+      PKG_PATH: ${{ inputs.registry }}/${{ inputs.organisation }}/${{ inputs.package-name }}
+      PKG_FILE: ${{ inputs.package-name }}.xpkg
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Crossplane CLI
+        run: |
+          echo "📦 Installing Crossplane CLI..."
+          curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
+          sudo mv crossplane /usr/local/bin/
+          
+          # Verify installation
+          crossplane version 2>/dev/null || echo "✅ Crossplane CLI installed (server not required)"
+
+      - name: Verify package structure
+        run: |
+          echo "📁 Verifying package structure..."
+          
+          # Package must be in configuration directory (convention)
+          if [ ! -f "configuration/crossplane.yaml" ]; then
+            echo "❌ ERROR: configuration/crossplane.yaml not found!"
+            echo "All packages must follow the standard structure:"
+            echo "  configuration/"
+            echo "  ├── crossplane.yaml"
+            echo "  ├── composition.yaml"
+            echo "  └── xrd.yaml"
+            exit 1
+          fi
+          
+          echo "✅ Found package in configuration/ directory"
+          echo "📁 Package contents:"
+          ls -la configuration/
+
+      - name: Add version label to XRD
+        run: |
+          echo "🏷️ Adding version label to XRD: ${VERSION}"
+          
+          # Add version to XRD
+          if [ -f "configuration/xrd.yaml" ]; then
+            yq -i '.metadata.labels."openportal.dev/version" = env(VERSION)' \
+              configuration/xrd.yaml
+            echo "✅ Updated configuration/xrd.yaml"
+          else
+            echo "⚠️ Warning: configuration/xrd.yaml not found - skipping version label"
+          fi
+
+      - name: Build Crossplane package
+        run: |
+          echo "🔨 Building Crossplane package..."
+          echo "  Package root: configuration/"
+          echo "  Output file: ${PKG_FILE}"
+          
+          crossplane xpkg build \
+            --package-root=configuration \
+            --package-file="${PKG_FILE}"
+          
+          # Verify package was created
+          if [ ! -f "${PKG_FILE}" ]; then
+            echo "❌ Package build failed - file not created"
+            exit 1
+          fi
+          
+          echo "✅ Package built successfully"
+          ls -lh "${PKG_FILE}"
+
+      - name: Push package to registry
+        run: |
+          echo "📤 Pushing package to registry..."
+          echo "  Registry: ${{ inputs.registry }}"
+          echo "  Package: ${PKG_PATH}:${VERSION}"
+          
+          # Push with version tag
+          crossplane xpkg push \
+            --package-files="${PKG_FILE}" \
+            "${PKG_PATH}:${VERSION}"
+          
+          echo "✅ Pushed ${PKG_PATH}:${VERSION}"
+          
+          # Push as 'latest' for stable releases (no pre-release suffix)
+          if [[ ! "${VERSION}" =~ - ]]; then
+            echo "📤 Additionally pushing as 'latest' tag..."
+            crossplane xpkg push \
+              --package-files="${PKG_FILE}" \
+              "${PKG_PATH}:latest"
+            echo "✅ Pushed ${PKG_PATH}:latest"
+          else
+            echo "ℹ️ Skipping 'latest' tag (pre-release version)"
+          fi
+
+      - name: Summary
+        run: |
+          echo "## 📦 Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Package Details" >> $GITHUB_STEP_SUMMARY
+          echo "- **Name:** \`${{ inputs.package-name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Registry:** \`${{ inputs.registry }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Organization:** \`${{ inputs.organisation }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Published Images" >> $GITHUB_STEP_SUMMARY
+          echo "- **Versioned:** \`${PKG_PATH}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          if [[ ! "${{ inputs.version }}" =~ - ]]; then
+            echo "- **Latest:** \`${PKG_PATH}:latest\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# GitHub Organization Settings
+
+This repository contains centralized configuration, workflows, and templates for the Open Service Portal GitHub organization.
+
+## Repository Structure
+
+```
+github-org-settings/
+├── .github/
+│   └── workflows/                              # Reusable workflows
+│       └── build-crossplane-package.yaml       # Crossplane package builder
+├── workflow-templates/                         # GitHub workflow templates
+│   ├── crossplane-package-release.yml          # Complete release workflow
+│   └── sync-labels.yml                         # Organization label sync
+├── images/                                     # Organization branding
+└── profile/                                    # Organization profile
+    └── README.md
+```
+
+## Components
+
+### Reusable Workflows (`.github/workflows/`)
+Centralized workflows that can be called from any repository in the organization. These provide standardized processes for common tasks like building Crossplane packages.
+
+[View Documentation](.github/workflows/README.md)
+
+### Workflow Templates (`workflow-templates/`)
+Ready-to-use workflow templates that appear in GitHub's "New workflow" interface. Teams can quickly adopt these standardized workflows without writing them from scratch.
+
+[View Documentation](workflow-templates/README.md)
+
+### Organization Profile (`profile/`)
+The public-facing README that appears on the organization's GitHub profile page.
+
+## Contributing
+
+When adding new workflows or templates:
+1. Place reusable workflows in `.github/workflows/`
+2. Place templates in `workflow-templates/` with a `.properties.json` file
+3. Update the relevant README.md with documentation
+4. Test thoroughly before merging to main

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -1,0 +1,87 @@
+# Workflow Templates
+
+GitHub workflow templates that appear in the "New workflow" interface for all repositories in the Open Service Portal organization.
+
+## Available Templates
+
+### 1. Crossplane Package Release (`crossplane-package-release.yml`)
+
+Complete workflow for releasing Crossplane packages with automated catalog updates.
+
+**What it does:**
+1. Gathers environment information (registry, org, package name, version)
+2. Builds and pushes package using the reusable build workflow
+3. Updates catalog via pull request (tag pushes only)
+4. Creates GitHub release with installation instructions
+
+**When to use:**
+- You have a Crossplane template repository
+- You want automated releases on tag push
+- You need catalog integration
+
+**Key Features:**
+- Manual testing via `workflow_dispatch`
+- Automatic pre-release detection
+- Catalog PR linking in release notes
+- Multi-architecture builds
+
+**Usage:**
+1. Go to Actions → New workflow
+2. Select "Crossplane Package Release"
+3. No customization needed - uses repository name and owner automatically
+
+### 2. Sync Organization Labels (`sync-labels.yml`)
+
+Synchronizes repository labels with organization standards.
+
+**What it does:**
+- Pulls label configuration from organization's `.github` repository
+- Updates repository labels to match organization standards
+- Runs weekly or on-demand
+- Preserves repository-specific labels
+
+**When to use:**
+- You want consistent labels across repositories
+- You need to align with organization standards
+- You're setting up a new repository
+
+**Schedule:**
+- Weekly: Sundays at midnight
+- Manual: Via workflow dispatch
+- On change: When workflow file is modified
+
+**Configuration:**
+- Labels defined in: `open-service-portal/.github` repository
+- Non-destructive: Won't delete repository-specific labels
+
+## Template Properties Files
+
+Each workflow template has a corresponding `.properties.json` file that controls:
+- **name**: Display name in GitHub UI
+- **description**: Help text for users
+- **iconName**: Visual icon (e.g., "package", "sync")
+- **categories**: Grouping in the template selector
+- **filePatterns**: When to suggest this template
+
+## How Templates Work
+
+1. **Discovery**: GitHub scans the `workflow-templates/` directory
+2. **Display**: Templates appear in "New workflow" for all org repositories  
+3. **Adoption**: Users select and commit the workflow
+4. **Customization**: Workflows auto-adapt using repository context
+
+## Adding New Templates
+
+1. Create `workflow-name.yml` in this directory
+2. Create `workflow-name.properties.json` with metadata
+3. Use repository context variables for auto-configuration:
+   - `${{ github.repository_owner }}` - Organization name
+   - `${{ github.event.repository.name }}` - Repository name
+   - `${{ github.ref_name }}` - Tag/branch name
+
+## Best Practices
+
+1. **Self-configuring**: Use context variables instead of hardcoded values
+2. **Documentation**: Include comments explaining each section
+3. **Flexibility**: Support both automated and manual triggers
+4. **Minimal configuration**: Work out-of-the-box without changes

--- a/workflow-templates/crossplane-package-release.properties.json
+++ b/workflow-templates/crossplane-package-release.properties.json
@@ -1,0 +1,17 @@
+{
+  "name": "Crossplane Package Release",
+  "description": "Automated workflow for building, publishing, and cataloging Crossplane packages",
+  "iconName": "kubernetes",
+  "categories": [
+    "Automation",
+    "Deployment",
+    "Infrastructure"
+  ],
+  "filePatterns": [
+    "xrd.yaml",
+    "crossplane.yaml",
+    "composition.yaml",
+    "^configuration/.*\\.yaml$",
+    "^template-.*"
+  ]
+}

--- a/workflow-templates/crossplane-package-release.yml
+++ b/workflow-templates/crossplane-package-release.yml
@@ -1,0 +1,123 @@
+# Template workflow for releasing Crossplane packages
+# This workflow orchestrates build, catalog update, and release creation
+name: Release Crossplane Package
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'  # Semantic version tags
+  
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to use (e.g., v1.0.0)'
+        required: true
+        default: 'v0.0.0-pre'
+
+jobs:
+  # Job 1: Gather environment information
+  vars:
+    name: Gather environment information
+    runs-on: ubuntu-latest
+    
+    outputs:
+      registry: ${{ steps.set-vars.outputs.registry }}
+      organisation: ${{ steps.set-vars.outputs.organisation }}
+      name: ${{ steps.set-vars.outputs.name }}
+      version: ${{ steps.set-vars.outputs.version }}
+    
+    steps:
+      - id: set-vars
+        run: |
+          # Registry is always ghcr.io for our organization
+          echo "registry=ghcr.io" >> $GITHUB_OUTPUT
+          
+          # Organization is the repository owner
+          echo "organisation=${{ github.repository_owner }}" >> $GITHUB_OUTPUT
+          
+          # Package name is the repository name
+          echo "name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+          
+          # Version comes from tag or manual input
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.ref_name }}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          
+          # Log the values for debugging
+          echo "📋 Configuration:"
+          echo "  Registry: ghcr.io"
+          echo "  Organization: ${{ github.repository_owner }}"
+          echo "  Package: ${{ github.event.repository.name }}"
+          echo "  Version: ${VERSION}"
+
+  # Job 2: Build and push the Crossplane package
+  build:
+    name: Build Package
+    needs: vars
+    uses: open-service-portal/github-org-settings/.github/workflows/build-crossplane-package.yaml@main
+    with:
+      package-name: ${{ needs.vars.outputs.name }}
+      version: ${{ needs.vars.outputs.version }}
+      registry: ${{ needs.vars.outputs.registry }}
+      organisation: ${{ needs.vars.outputs.organisation }}
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+
+  # Job 3: Update catalog (only on tag push)
+  catalog:
+    name: Update Catalog
+    needs: [vars, build]
+    # Only run for tag pushes, not manual dispatch testing
+    if: github.event_name == 'push'
+    uses: open-service-portal/catalog/.github/workflows/update-catalog-entry.yaml@main
+    with:
+      package-name: ${{ needs.vars.outputs.name }}
+      version: ${{ needs.vars.outputs.version }}
+      registry: ${{ needs.vars.outputs.registry }}
+      organisation: ${{ needs.vars.outputs.organisation }}
+    secrets: inherit
+
+  # Job 4: Create a GitHub release (only on tag push)
+  release:
+    name: Create Release
+    needs: [vars, build, catalog]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+    
+    env:
+      VERSION: ${{ needs.vars.outputs.version }}
+      PKG_PATH: ${{ needs.vars.outputs.registry }}/${{ needs.vars.outputs.organisation }}/${{ needs.vars.outputs.name }}
+    
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ needs.vars.outputs.version }}
+          body: |
+            ## Package: ${{ needs.vars.outputs.name }} ${{ needs.vars.outputs.version }}
+            
+            ### Installation
+
+            ```bash
+            kubectl apply -f - <<EOF
+            apiVersion: pkg.crossplane.io/v1
+            kind: Configuration
+            metadata:
+              name: ${{ needs.vars.outputs.name }}
+              namespace: crossplane-system
+            spec:
+              package: ${{ needs.vars.outputs.registry }}/${{ needs.vars.outputs.organisation }}/${{ needs.vars.outputs.name }}:${{ needs.vars.outputs.version }}
+            EOF
+            ```
+            
+            ### Catalog Update
+            - PR: ${{ needs.catalog.outputs.pr-url || 'Pending' }}
+          prerelease: ${{ contains(needs.vars.outputs.version, '-') }}


### PR DESCRIPTION
## Summary

This PR introduces centralized workflows and templates for building and releasing Crossplane packages across the organization. It eliminates duplicate workflow code and enforces consistent build practices.

## What's New

### 🔧 Reusable Build Workflow
- **File**: `.github/workflows/build-crossplane-package.yaml`
- Standardized package building process
- Enforces conventions (packages in `configuration/` directory)
- Multi-architecture builds (linux/amd64, linux/arm64)
- Automatic `latest` tag for stable releases
- Version labels applied to XRDs

### 📋 Workflow Templates
- **Crossplane Package Release**: Complete release automation template
  - Available via GitHub's "New workflow" interface
  - Auto-configures using repository context
  - Orchestrates build → catalog update → GitHub release

### 📚 Documentation
- Comprehensive README files for workflows and templates
- Usage examples and migration guides
- Troubleshooting sections

## Benefits

✅ **DRY Principle**: Build logic centralized in one place
✅ **Consistency**: All packages built using the same process
✅ **Convention over Configuration**: Enforces standard package structure
✅ **Easy Adoption**: Templates available in GitHub UI
✅ **Maintainability**: Update once, benefit everywhere

## Usage Example

Template repositories can now use a minimal workflow:

```yaml
jobs:
  build:
    uses: open-service-portal/github-org-settings/.github/workflows/build-crossplane-package.yaml@main
    with:
      package-name: ${{ github.event.repository.name }}
      version: ${{ github.ref_name }}
      organisation: ${{ github.repository_owner }}
    permissions:
      contents: read
      packages: write
    secrets: inherit
```

## Related Work

- Companion to the `update-catalog-entry.yaml` workflow in the catalog repository
- Supports the automated catalog update pattern
- Works with existing template repositories after migration to `configuration/` structure

## Testing

- [x] Workflow syntax validated
- [x] Template properties files included
- [x] Documentation complete
- [ ] Test with actual package build (after merge)
- [ ] Verify template appears in GitHub UI (after merge)

## Next Steps

1. Merge this PR to make workflows available
2. Update template repositories to use the new workflows
3. Remove duplicate workflow code from individual repositories

---
*This completes the CI/CD automation initiative for Crossplane packages.*