### PR TITLE
fix: correct workflow reference path in template

### DIFF
--- a/workflow-templates/crossplane-package-release.yml
+++ b/workflow-templates/crossplane-package-release.yml
@@ -57,7 +57,7 @@ jobs:
   build:
     name: Build Package
     needs: vars
-    uses: open-service-portal/github-org-settings/.github/workflows/build-crossplane-package.yaml@main
+    uses: open-service-portal/.github/.github/workflows/build-crossplane-package.yaml@main
     with:
       package-name: ${{ needs.vars.outputs.name }}
       version: ${{ needs.vars.outputs.version }}


### PR DESCRIPTION
## Summary

Fixed the workflow reference path in the Crossplane package release template.

The path now correctly points to the reusable workflow in the `.github` repository.